### PR TITLE
Integração com banco de dados remoto e atualização do perfil de testes

### DIFF
--- a/contratos/src/main/java/com/getinfo/contratos/ContratosApplication.java
+++ b/contratos/src/main/java/com/getinfo/contratos/ContratosApplication.java
@@ -5,7 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Profile;
 
 @SpringBootApplication
-@Profile("dev")
+//#Caso queira testar com banco de dados local, descomente.
+//@Profile("dev")
 public class ContratosApplication {
 
 	public static void main(String[] args) {

--- a/contratos/src/main/resources/application-dev.properties
+++ b/contratos/src/main/resources/application-dev.properties
@@ -7,6 +7,5 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
-# Esse perfil será usado para testar a aplicação localmente no pc de vocês,
-# por exemplo, caso for rodar na unit e não tenha o banco de dados igual está especificado aqui
-# vocês podem criar algum qualquer e só botar ele aqui.
+# Esse perfil será usado para testar a aplicação localmente no banco de dados do pc de vocês,
+

--- a/contratos/src/main/resources/application.properties
+++ b/contratos/src/main/resources/application.properties
@@ -1,11 +1,15 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/contratosdb
-spring.datasource.username=contratos_user
-spring.datasource.password=getinfo123
+spring.datasource.url=SPRING_DATASOURCE_URL
+spring.datasource.username=SPRING_DATASOURCE_USERNAME
+spring.datasource.password=SPRING_DATASOURCE_PASSWORD
+
+
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.profiles.active=${ACTIVE_PROFILE:dev}
+#Caso queira testar com banco de dados local, descomente.
+#spring.profiles.active=${ACTIVE_PROFILE:dev}
+
 
 


### PR DESCRIPTION
Adicionado conexão com banco de dados remoto, e substituição das credencias por variáveis de ambiente;
Troquei a lógica de perfil para o perfil principal da api rodar nesse banco de dados remoto, mas deixei o perfil de teste pronto para trocar para o banco de dados local (Deixei comentários explicando).